### PR TITLE
main: Reenable shared OpenGL contexts

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv) {
     QGuiApplication::setOrganizationName("youtube-web.mateo-salta");
     QGuiApplication::setApplicationName("youtube-web.mateo-salta");
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    //QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
+    QGuiApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 
     //qputenv("QTWEBENGINE_CHROMIUM_FLAGS", "");
     


### PR DESCRIPTION
OpenGL context sharing is required for QtWebEngine to flip into hardware-accelerated rendering mode and enable video decoding codepaths implemented in focal.